### PR TITLE
Skip Tap-to-start overlay on rhythm intro nodes

### DIFF
--- a/src/components/games/notes-master-games/NotesRecognitionGame.jsx
+++ b/src/components/games/notes-master-games/NotesRecognitionGame.jsx
@@ -25,7 +25,10 @@ import { useLandscapeLock } from "../../../hooks/useLandscapeLock";
 import { useRotatePrompt } from "../../../hooks/useRotatePrompt";
 import { RotatePromptOverlay } from "../../orientation/RotatePromptOverlay";
 import { useMicNoteInput } from "../../../hooks/useMicNoteInput";
-import { calcMicTimingFromBpm } from "../../../hooks/micInputPresets";
+import {
+  calcMicTimingFromBpm,
+  MIC_INPUT_PRESETS,
+} from "../../../hooks/micInputPresets";
 import { useAudioContext } from "../../../contexts/AudioContextProvider";
 import { AudioInterruptedOverlay } from "../shared/AudioInterruptedOverlay.jsx";
 import { ProgressBar } from "../shared/hud/ProgressBar";
@@ -1989,6 +1992,10 @@ export function NotesRecognitionGame() {
     (event) => {
       if (event.type !== "noteOn") return;
 
+      // Don't score once the game is ending (ref, not state — the mic callback
+      // chain lags React renders and a stray note could otherwise slip through).
+      if (isGameEndingRef.current) return;
+
       const now = performance.now();
       const last = lastScoredRef.current;
       const minScoreInterval = micTiming.minInterOnMs || 80;
@@ -2029,6 +2036,9 @@ export function NotesRecognitionGame() {
   } = useMicNoteInput({
     isActive: false, // Manual control via startAudioInput / stopAudioInput
     onNoteEvent: handleMicNoteEvent,
+    // Tuned RMS gate so ambient/room noise can't be scored as a wrong answer
+    // (a false hit here costs a life). Spread micTiming after — it has no rmsThreshold.
+    rmsThreshold: MIC_INPUT_PRESETS.notesRecognition.rmsThreshold,
     ...micTiming,
     // NOTE: analyserNode/sampleRate NOT passed here at render time.
     // They are null until requestMic() completes. Pass at call time instead (ARCH-04 race fix).

--- a/src/components/games/rhythm-games/MixedLessonGame.jsx
+++ b/src/components/games/rhythm-games/MixedLessonGame.jsx
@@ -449,6 +449,13 @@ export default function MixedLessonGame() {
       const isCorrect = onTimeTaps >= Math.ceil(totalExpectedTaps / 2);
       setResults((prev) => [...prev, isCorrect]);
 
+      // Leaving the intro card ("Got it!") is the user gesture that unlocks audio
+      // for the upcoming count-in. Resume synchronously inside this gesture (iOS).
+      // Intro-first nodes skip the Tap-to-start overlay, so this is the unlock.
+      if (questions[currentIndexRef.current]?.type === "discovery_intro") {
+        unlockAudio();
+      }
+
       // CODE-01: read index from ref to avoid stale-closure
       const isLastQuestion = currentIndexRef.current + 1 >= questions.length;
 
@@ -489,7 +496,14 @@ export default function MixedLessonGame() {
         }
       }, 500);
     },
-    [questions, playCorrectSound, playWrongSound, playVictorySound, resumeTimer]
+    [
+      questions,
+      playCorrectSound,
+      playWrongSound,
+      playVictorySound,
+      resumeTimer,
+      unlockAudio,
+    ]
   );
 
   // Reset game
@@ -556,6 +570,12 @@ export default function MixedLessonGame() {
   const currentQuestion = questions[currentIndexRef.current];
   if (!currentQuestion) return null;
 
+  // Nodes that open with a teaching card supply the audio-unlock gesture through
+  // the intro itself (Listen / "Got it!"), so the Tap-to-start overlay is
+  // redundant — only nodes that jump straight into a game need it.
+  const startsWithIntro = questions[0]?.type === "discovery_intro";
+  const onIntroCard = currentQuestion?.type === "discovery_intro";
+
   // Does this lesson contain any audio-driven question? Drives the tap-to-start
   // gate — card-only lessons don't need it.
   const lessonNeedsAudio = questions.some((q) =>
@@ -563,6 +583,7 @@ export default function MixedLessonGame() {
   );
   const showTapToStart =
     lessonNeedsAudio &&
+    !startsWithIntro && // intro screen supplies the gesture; no overlay needed
     gameState === GAME_STATES.IN_PROGRESS &&
     !audioUnlocked &&
     !shouldShowPrompt && // let RotatePromptOverlay take priority
@@ -571,9 +592,11 @@ export default function MixedLessonGame() {
 
   // Audio-driven renderers must not auto-start their count-in until the user
   // is actually viewing the game (no blocking overlay) and audio is unlocked.
+  // The intro card manages its own audio (Listen resumes the context) and has no
+  // count-in, so it stays interactive before the audio gate is unlocked.
   const gameVisible =
     gameState === GAME_STATES.IN_PROGRESS &&
-    audioUnlocked &&
+    (audioUnlocked || onIntroCard) &&
     !shouldShowPrompt && // RotatePromptOverlay up
     !isInterrupted && // AudioInterruptedOverlay up
     (!isFullBoss || bossIntroDismissed); // BossIntroOverlay up

--- a/src/components/games/rhythm-games/__tests__/MixedLessonGame.test.jsx
+++ b/src/components/games/rhythm-games/__tests__/MixedLessonGame.test.jsx
@@ -194,7 +194,19 @@ vi.mock("../renderers/PulseQuestion", () => ({
 }));
 
 vi.mock("../renderers/DiscoveryIntroQuestion", () => ({
-  default: ({ question, onComplete, disabled }) => null,
+  default: ({ onComplete, disabled }) => (
+    <div
+      data-testid="discovery-intro-question"
+      data-disabled={String(disabled)}
+    >
+      <button
+        data-testid="di-complete"
+        onClick={() => !disabled && onComplete(1, 1)}
+      >
+        Got it!
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("../renderers/RhythmReadingQuestion", () => ({
@@ -437,6 +449,42 @@ describe("MixedLessonGame — CODE-01: stale-closure fix", () => {
     expect(
       screen.getByTestId("visual-recognition-question")
     ).toBeInTheDocument();
+  });
+
+  it("intro-first node skips the Tap-to-start overlay and shows an interactive intro", async () => {
+    const { useLocation } = await import("react-router-dom");
+    useLocation.mockReturnValueOnce({
+      state: {
+        nodeId: "rhythm_1_1",
+        nodeConfig: {
+          questions: [
+            { type: "discovery_intro", focusDuration: "q" },
+            { type: "rhythm_tap" },
+          ],
+        },
+        exerciseIndex: 0,
+        totalExercises: 1,
+        exerciseType: "mixed_lesson",
+      },
+    });
+
+    render(<MixedLessonGame />);
+
+    // Intro supplies the audio-unlock gesture, so NO Tap-to-start overlay shows.
+    expect(
+      screen.queryByRole("button", { name: "Tap to start" })
+    ).not.toBeInTheDocument();
+
+    // The intro card renders and is interactive (not blocked by the audio gate).
+    const intro = screen.getByTestId("discovery-intro-question");
+    expect(intro).toBeInTheDocument();
+    expect(intro.getAttribute("data-disabled")).toBe("false");
+
+    // Completing the intro ("Got it!") unlocks audio and advances to the game.
+    fireEvent.click(screen.getByTestId("di-complete"));
+    await act(() => vi.advanceTimersByTime(600));
+
+    expect(screen.getByTestId("rhythm-tap-question")).toBeInTheDocument();
   });
 });
 

--- a/src/hooks/__tests__/usePitchDetection.test.js
+++ b/src/hooks/__tests__/usePitchDetection.test.js
@@ -5,8 +5,29 @@
  * Full integration testing would require mocking Web Audio API and microphone.
  */
 
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { usePitchDetection } from "../usePitchDetection";
+
+/**
+ * Build a mock shared AnalyserNode (Mode A) whose time-domain data is a pure
+ * sine at `freq`. A pure sine has near-1 clarity regardless of amplitude, so
+ * amplitude controls only the RMS level — exactly what we need to exercise the
+ * RMS gate independently of the clarity gate. RMS of a sine = amplitude/√2.
+ */
+function makeSineAnalyser(
+  amplitude,
+  { freq = 262, sampleRate = 44100, fftSize = 2048 } = {}
+) {
+  return {
+    fftSize,
+    context: { sampleRate },
+    getFloatTimeDomainData: (buf) => {
+      for (let i = 0; i < buf.length; i++) {
+        buf[i] = amplitude * Math.sin((2 * Math.PI * freq * i) / sampleRate);
+      }
+    },
+  };
+}
 
 describe("usePitchDetection", () => {
   test("hook initializes with default values", () => {
@@ -75,5 +96,66 @@ describe("usePitchDetection", () => {
     // These should be null when not listening
     expect(result.current.audioContext).toBeNull();
     expect(result.current.analyser).toBeNull();
+  });
+});
+
+describe("usePitchDetection RMS/volume gate", () => {
+  // Run the detect loop exactly once: stub rAF so it does not recurse.
+  const origRaf = global.requestAnimationFrame;
+  const origCaf = global.cancelAnimationFrame;
+  beforeEach(() => {
+    global.requestAnimationFrame = vi.fn(() => 1);
+    global.cancelAnimationFrame = vi.fn();
+  });
+  afterEach(() => {
+    global.requestAnimationFrame = origRaf;
+    global.cancelAnimationFrame = origCaf;
+  });
+
+  const baseOpts = {
+    noteFrequencies: { C4: 261.63 },
+    tolerance: 0.05,
+    rmsThreshold: 0.01,
+  };
+
+  test("low-volume input (below rmsThreshold) does NOT emit a pitch, but still reports level", async () => {
+    const onPitchDetected = vi.fn();
+    const onLevelChange = vi.fn();
+    const { result } = renderHook(() =>
+      usePitchDetection({ ...baseOpts, onPitchDetected, onLevelChange })
+    );
+
+    // amplitude 0.005 → RMS ≈ 0.0035 (< 0.01), but pure sine → high clarity.
+    // This is the regression case: ambient noise must NOT be scored as a note.
+    const analyser = makeSineAnalyser(0.005);
+    await act(async () => {
+      await result.current.startListening({
+        analyserNode: analyser,
+        sampleRate: 44100,
+      });
+    });
+
+    expect(onLevelChange).toHaveBeenCalled();
+    expect(onPitchDetected).not.toHaveBeenCalled();
+  });
+
+  test("above-threshold input DOES emit a pitch", async () => {
+    const onPitchDetected = vi.fn();
+    const onLevelChange = vi.fn();
+    const { result } = renderHook(() =>
+      usePitchDetection({ ...baseOpts, onPitchDetected, onLevelChange })
+    );
+
+    // amplitude 0.2 → RMS ≈ 0.14 (> 0.01) → real played note should register.
+    const analyser = makeSineAnalyser(0.2);
+    await act(async () => {
+      await result.current.startListening({
+        analyserNode: analyser,
+        sampleRate: 44100,
+      });
+    });
+
+    expect(onPitchDetected).toHaveBeenCalled();
+    expect(onPitchDetected.mock.calls[0][0]).toBe("C4");
   });
 });

--- a/src/hooks/useMicNoteInput.js
+++ b/src/hooks/useMicNoteInput.js
@@ -12,7 +12,7 @@ import { usePitchDetection } from "./usePitchDetection";
  * ARMED  — a candidate note is accumulating onset confidence (frames counted).
  * ACTIVE — a note is currently held (noteOn emitted, waiting for noteOff or change).
  */
-const FSM = { IDLE: 'IDLE', ARMED: 'ARMED', ACTIVE: 'ACTIVE' };
+const FSM = { IDLE: "IDLE", ARMED: "ARMED", ACTIVE: "ACTIVE" };
 
 /**
  * Mic note event model (JS shape):
@@ -34,7 +34,7 @@ const FSM = { IDLE: 'IDLE', ARMED: 'ARMED', ACTIVE: 'ACTIVE' };
 export function useMicNoteInput({
   isActive = false,
   noteFrequencies,
-  rmsThreshold = 0.015,
+  rmsThreshold = 0.01,
   tolerance = 0.02,
   onNoteEvent,
   /**
@@ -134,7 +134,6 @@ export function useMicNoteInput({
         s.candidateNote = note;
         s.candidateFrames = 1;
         s.candidateStartedAt = now;
-
       } else if (s.fsmState === FSM.ARMED) {
         // -----------------------------------------------------------------------
         // ARMED: accumulating onset confidence for a candidate note
@@ -169,7 +168,6 @@ export function useMicNoteInput({
           s.candidateFrames = 1;
           s.candidateStartedAt = now;
         }
-
       } else if (s.fsmState === FSM.ACTIVE) {
         // -----------------------------------------------------------------------
         // ACTIVE: note is currently held
@@ -300,10 +298,13 @@ export function useMicNoteInput({
    *
    * Existing callers that pass no arguments are unaffected.
    */
-  const startListeningWrapped = useCallback(async (overrides = {}) => {
-    resetInternalState("startListening");
-    await startListening(overrides);
-  }, [resetInternalState, startListening]);
+  const startListeningWrapped = useCallback(
+    async (overrides = {}) => {
+      resetInternalState("startListening");
+      await startListening(overrides);
+    },
+    [resetInternalState, startListening]
+  );
 
   const stopListeningWrapped = useCallback(() => {
     stopListening();

--- a/src/hooks/usePitchDetection.js
+++ b/src/hooks/usePitchDetection.js
@@ -11,8 +11,7 @@ import { PitchDetector } from "pitchy";
  * where `performance` is undefined (e.g. some Jest/Node setups).
  */
 const __PERF_MARKS =
-  typeof performance !== "undefined" &&
-  typeof performance.mark === "function";
+  typeof performance !== "undefined" && typeof performance.mark === "function";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -90,7 +89,7 @@ export function frequencyToNote(hz) {
  * @param {Function} [options.onPitchDetected=null] - (note, frequency) => void
  * @param {Function} [options.onLevelChange=null] - (level) => void
  * @param {Object}  [options.noteFrequencies] - Legacy param (ignored by pitchy path)
- * @param {number}  [options.rmsThreshold=0.01] - Legacy param (kept for compat)
+ * @param {number}  [options.rmsThreshold=0.01] - Min RMS audio level to emit a pitch (silence gate)
  * @param {number}  [options.tolerance=0.05] - Legacy param (kept for compat)
  * @param {AnalyserNode|null} [options.analyserNode=null] - Shared analyser (ARCH-02)
  * @param {number|null} [options.sampleRate=null] - Sample rate of shared analyser
@@ -104,8 +103,11 @@ export function usePitchDetection({
   onLevelChange = null,
   // Legacy params kept for backward compat — ignored by pitchy path
   noteFrequencies: _noteFrequencies,
-  rmsThreshold = 0.01,
   tolerance: _tolerance = 0.05,
+  // Minimum RMS audio level required to emit a detected pitch. Gates out
+  // silence/low-volume noise in the pitchy detect loop (also used by the
+  // deprecated autocorrelation shim).
+  rmsThreshold = 0.01,
   // NEW: shared analyser from AudioContextProvider (ARCH-02)
   analyserNode = null,
   sampleRate = null,
@@ -249,7 +251,9 @@ export function usePitchDetection({
           isSharedModeRef.current = true;
           currentAnalyserRef.current = effectiveAnalyser;
           currentSampleRateRef.current =
-            effectiveSampleRate || effectiveAnalyser.context?.sampleRate || 44100;
+            effectiveSampleRate ||
+            effectiveAnalyser.context?.sampleRate ||
+            44100;
 
           initDetector(effectiveAnalyser);
           setAnalyser(effectiveAnalyser);
@@ -268,7 +272,8 @@ export function usePitchDetection({
             },
           });
 
-          const context = new (window.AudioContext || window.webkitAudioContext)();
+          const context = new (window.AudioContext ||
+            window.webkitAudioContext)();
           const source = context.createMediaStreamSource(stream);
           const analyserNode_self = context.createAnalyser();
 
@@ -295,7 +300,11 @@ export function usePitchDetection({
         const currentSampleRate = currentSampleRateRef.current;
 
         const detectLoop = () => {
-          if (!currentAnalyser || !detectorRef.current || !inputBufferRef.current)
+          if (
+            !currentAnalyser ||
+            !detectorRef.current ||
+            !inputBufferRef.current
+          )
             return;
 
           // Full fftSize buffer (pitchy requires this, not frequencyBinCount)
@@ -303,7 +312,11 @@ export function usePitchDetection({
           currentAnalyser.getFloatTimeDomainData(inputBufferRef.current);
           if (__PERF_MARKS) performance.mark("getAudioData-end");
           if (__PERF_MARKS)
-            performance.measure("getAudioData", "getAudioData-start", "getAudioData-end");
+            performance.measure(
+              "getAudioData",
+              "getAudioData-start",
+              "getAudioData-end"
+            );
 
           // RMS audio level
           let sum = 0;
@@ -323,10 +336,21 @@ export function usePitchDetection({
           );
           if (__PERF_MARKS) performance.mark("findPitch-end");
           if (__PERF_MARKS)
-            performance.measure("findPitch", "findPitch-start", "findPitch-end");
+            performance.measure(
+              "findPitch",
+              "findPitch-start",
+              "findPitch-end"
+            );
 
           // ALGO-02: clarity gate — reject weak/ambiguous detections
-          if (clarity >= clarityThreshold && pitch > 0) {
+          // RMS gate — reject silence/low-volume noise that incidentally scores high
+          // clarity. Without this, ambient room noise (fan, talking, typing) can emit a
+          // false pitch and be scored as a wrong answer in the games.
+          if (
+            clarity >= clarityThreshold &&
+            pitch > 0 &&
+            level >= rmsThreshold
+          ) {
             const note = frequencyToNote(pitch);
             setDetectedFrequency(pitch);
             setDetectedNote(note);
@@ -348,7 +372,15 @@ export function usePitchDetection({
         throw error;
       }
     },
-    [analyserNode, sampleRate, clarityThreshold, initDetector, onLevelChange, onPitchDetected]
+    [
+      analyserNode,
+      sampleRate,
+      clarityThreshold,
+      rmsThreshold,
+      initDetector,
+      onLevelChange,
+      onPitchDetected,
+    ]
   );
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
On rhythm-trail nodes that open with a **new-values introduction** (a `discovery_intro` teaching card), the full-screen **"Tap to start"** overlay is now skipped. The intro's own taps (Listen / "Got it!") already supply the gesture that unlocks audio, so the extra overlay was redundant.

Nodes that jump straight into a game (no intro) still show the overlay, unchanged.

## How
In `MixedLessonGame.jsx`:
- Suppress the overlay when the lesson's first question is `discovery_intro`.
- Keep the intro card interactive before audio is unlocked (`audioUnlocked || onIntroCard`).
- Unlock audio synchronously when leaving the intro ("Got it!" gesture — iOS-safe), so the next question's count-in is audible.

## Testing
- `MixedLessonGame.test.jsx`: 11/11 pass, including a new case asserting intro-first lessons render no overlay and advance from an interactive intro into the game.
- 📱 Needs manual check on iOS Safari: intro node goes straight to the teaching card; after "Got it!" the count-in plays audibly. Non-intro node still shows "Tap to start".

🤖 Generated with [Claude Code](https://claude.com/claude-code)