### PR TITLE
fix(rhythm): re-apply count-in freeze fix to trail audio renderers

### DIFF
--- a/src/components/games/rhythm-games/renderers/PulseQuestion.jsx
+++ b/src/components/games/rhythm-games/renderers/PulseQuestion.jsx
@@ -95,6 +95,13 @@ const makeResetTapResults = (beatsPerMeasure) =>
     quality: null,
   }));
 
+// Count-in auto-start retry. A remounted audio question (2nd+ question in a
+// MixedLessonGame) can briefly observe a not-yet-running shared AudioContext;
+// without a retry the count-in bails permanently and the game freezes. Re-arm
+// the start effect a few times so it self-heals once the context is running.
+const MAX_START_RETRIES = 6;
+const START_RETRY_MS = 150;
+
 export default function PulseQuestion({
   question,
   isLandscape: _isLandscape,
@@ -155,7 +162,11 @@ export default function PulseQuestion({
   const playingTimerRef = useRef(null);
   const scheduledOscillatorsRef = useRef([]);
   const hasStartedRef = useRef(false);
-  const cleanupDoneRef = useRef(false);
+
+  // Count-in auto-start retry plumbing — see MAX_START_RETRIES note above.
+  const [startRetryTick, setStartRetryTick] = useState(0);
+  const startRetryCountRef = useRef(0);
+  const startRetryTimerRef = useRef(null);
 
   // Hold note refs (Phase 31) — rAF-driven, no React state updates at 60fps
   const pressStartTimeRef = useRef(null);
@@ -355,6 +366,14 @@ export default function PulseQuestion({
       });
     scheduledOscillatorsRef.current = [];
   }, [audioEngine]);
+
+  // Stable ref to the latest stop fn. stopContinuousMetronome closes over the
+  // per-render `audioEngine` object, so its identity changes every render. The
+  // unmount cleanup below must NOT depend on it — listing it made the cleanup
+  // fire on ordinary re-renders, tearing down the live metronome intervals
+  // mid-exercise (the count-in freeze on 2nd+ audio questions).
+  const stopContinuousMetronomeRef = useRef(stopContinuousMetronome);
+  stopContinuousMetronomeRef.current = stopContinuousMetronome;
 
   // Evaluate taps using accumulated per-beat results
   const evaluatePerformance = useCallback(() => {
@@ -567,8 +586,22 @@ export default function PulseQuestion({
     const running = await audioEngine.ensureRunning();
     if (!running) {
       hasStartedRef.current = false;
+      if (import.meta.env.DEV) {
+        console.info("[rhythm count-in] context not running, retrying", {
+          attempt: startRetryCountRef.current,
+          ctxState: audioEngine.audioContextRef?.current?.state,
+        });
+      }
+      if (startRetryCountRef.current < MAX_START_RETRIES) {
+        startRetryCountRef.current += 1;
+        startRetryTimerRef.current = setTimeout(
+          () => setStartRetryTick((n) => n + 1),
+          START_RETRY_MS
+        );
+      }
       return;
     }
+    startRetryCountRef.current = 0; // running — reset budget for future remounts
 
     // Prime the audio pipeline with a silent oscillator so the first
     // real click isn't swallowed by an uninitialized output buffer.
@@ -642,23 +675,24 @@ export default function PulseQuestion({
     evaluatePerformance,
   ]);
 
-  // Auto-start when not disabled (hasStartedRef pattern)
+  // Auto-start when not disabled (hasStartedRef pattern). startRetryTick re-arms
+  // this after a transient not-running AudioContext so the count-in self-heals.
   useEffect(() => {
     if (!disabled && phase === PHASES.WAITING) {
       startFlow();
     }
-  }, [disabled, phase, startFlow]);
+  }, [disabled, phase, startFlow, startRetryTick]);
 
-  // Cleanup on unmount — cancel rAF loop (T-31-08) and metronome
+  // Cleanup on unmount ONLY — cancel rAF loop (T-31-08) and metronome. Empty
+  // deps so this fires exactly once on real unmount; the stop fn is read through
+  // a ref to avoid the identity-churn bug described above.
   useEffect(() => {
     return () => {
-      if (!cleanupDoneRef.current) {
-        cleanupDoneRef.current = true;
-        stopContinuousMetronome();
-        cancelAnimationFrame(rafIdRef.current);
-      }
+      stopContinuousMetronomeRef.current();
+      cancelAnimationFrame(rafIdRef.current);
+      if (startRetryTimerRef.current) clearTimeout(startRetryTimerRef.current);
     };
-  }, [stopContinuousMetronome]);
+  }, []);
 
   // Guidance text by phase
   const getGuidanceText = () => {

--- a/src/components/games/rhythm-games/renderers/RhythmReadingQuestion.jsx
+++ b/src/components/games/rhythm-games/renderers/RhythmReadingQuestion.jsx
@@ -55,6 +55,13 @@ const TIME_SIG_MAP = {
   "6/8": TIME_SIGNATURES.SIX_EIGHT,
 };
 
+// Count-in auto-start retry. A remounted audio question (2nd+ question in a
+// MixedLessonGame) can briefly observe a not-yet-running shared AudioContext;
+// without a retry the count-in bails permanently and the game freezes. Re-arm
+// the start effect a few times so it self-heals once the context is running.
+const MAX_START_RETRIES = 6;
+const START_RETRY_MS = 150;
+
 export default function RhythmReadingQuestion({
   question,
   isLandscape: _isLandscape,
@@ -99,7 +106,11 @@ export default function RhythmReadingQuestion({
   // Refs
   const hasStartedRef = useRef(false);
   const hasAnchoredRef = useRef(false); // pattern anchored to the user's first tap (Bug 2)
-  const cleanupDoneRef = useRef(false);
+
+  // Count-in auto-start retry plumbing — see MAX_START_RETRIES note above.
+  const [startRetryTick, setStartRetryTick] = useState(0);
+  const startRetryCountRef = useRef(0);
+  const startRetryTimerRef = useRef(null);
   const patternStartTimeRef = useRef(0);
   const scheduledBeatTimesRef = useRef([]);
   const nextBeatIndexRef = useRef(0);
@@ -228,6 +239,14 @@ export default function RhythmReadingQuestion({
       });
     scheduledOscillatorsRef.current = [];
   }, [audioEngine]);
+
+  // Stable ref to the latest stop fn. stopContinuousMetronome closes over the
+  // per-render `audioEngine` object, so its identity changes every render. The
+  // unmount cleanup below must NOT depend on it — listing it made the cleanup
+  // fire on ordinary re-renders, tearing down the live metronome intervals
+  // mid-exercise (the count-in freeze on 2nd+ audio questions).
+  const stopContinuousMetronomeRef = useRef(stopContinuousMetronome);
+  stopContinuousMetronomeRef.current = stopContinuousMetronome;
 
   // Stave bounds callback
   const handleStaveBoundsReady = useCallback((bounds) => {
@@ -516,8 +535,23 @@ export default function RhythmReadingQuestion({
     const running = await audioEngine.ensureRunning();
     if (!running) {
       hasStartedRef.current = false;
+      if (import.meta.env.DEV) {
+        console.info("[rhythm count-in] READ context not running, retrying", {
+          attempt: startRetryCountRef.current,
+          shared: audioContextRef.current?.state,
+          eng: audioEngine.audioContextRef?.current?.state,
+        });
+      }
+      if (startRetryCountRef.current < MAX_START_RETRIES) {
+        startRetryCountRef.current += 1;
+        startRetryTimerRef.current = setTimeout(
+          () => setStartRetryTick((n) => n + 1),
+          START_RETRY_MS
+        );
+      }
       return;
     }
+    startRetryCountRef.current = 0; // running — reset budget for future remounts
 
     // Prime audio pipeline
     try {
@@ -614,23 +648,25 @@ export default function RhythmReadingQuestion({
 
     setBeats(loadedBeats);
     startFlow();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time start
-  }, [disabled]);
+    // startRetryTick re-arms this after a transient not-running AudioContext so
+    // the count-in self-heals (see startFlow).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only disabled + retry tick drive (re)start
+  }, [disabled, startRetryTick]);
 
-  // Cleanup on unmount
+  // Cleanup on unmount ONLY. Empty deps so this fires exactly once on real
+  // unmount; the stop fn is read through a ref to avoid the identity-churn bug
+  // described above.
   useEffect(() => {
     return () => {
-      if (!cleanupDoneRef.current) {
-        cleanupDoneRef.current = true;
-        stopContinuousMetronome();
-        if (rafIdRef.current) {
-          cancelAnimationFrame(rafIdRef.current);
-          rafIdRef.current = null;
-        }
-        cancelAnimationFrame(holdRafIdRef.current);
+      stopContinuousMetronomeRef.current();
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
       }
+      cancelAnimationFrame(holdRafIdRef.current);
+      if (startRetryTimerRef.current) clearTimeout(startRetryTimerRef.current);
     };
-  }, [stopContinuousMetronome]);
+  }, []);
 
   // Guidance text
   const getGuidanceText = () => {

--- a/src/components/games/rhythm-games/renderers/RhythmTapQuestion.jsx
+++ b/src/components/games/rhythm-games/renderers/RhythmTapQuestion.jsx
@@ -77,6 +77,13 @@ const SCORING = { PERFECT: 100, GOOD: 75, FAIR: 50, MISS: 0 };
 // what they hear, so subtract this from relativeTime before evaluation.
 const FALLBACK_LATENCY_S = 0.08; // 80ms fallback
 
+// Count-in auto-start retry. A remounted audio question (2nd+ question in a
+// MixedLessonGame) can briefly observe a not-yet-running shared AudioContext;
+// without a retry the count-in bails permanently and the game freezes. Re-arm
+// the start effect a few times so it self-heals once the context is running.
+const MAX_START_RETRIES = 6;
+const START_RETRY_MS = 150;
+
 // Time signature string → object mapping
 const TIME_SIG_MAP = {
   "4/4": TIME_SIGNATURES.FOUR_FOUR,
@@ -149,7 +156,11 @@ export default function RhythmTapQuestion({
   const visualMetronomeRef = useRef(null);
   const scheduledOscillatorsRef = useRef([]);
   const hasStartedRef = useRef(false);
-  const cleanupDoneRef = useRef(false);
+
+  // Count-in auto-start retry plumbing — see MAX_START_RETRIES note above.
+  const [startRetryTick, setStartRetryTick] = useState(0);
+  const startRetryCountRef = useRef(0);
+  const startRetryTimerRef = useRef(null);
 
   // Hold mechanic refs
   const currentOnsetIndexRef = useRef(0);
@@ -301,6 +312,14 @@ export default function RhythmTapQuestion({
       });
     scheduledOscillatorsRef.current = [];
   }, [audioEngine]);
+
+  // Stable ref to the latest stop fn. stopContinuousMetronome closes over the
+  // per-render `audioEngine` object, so its identity changes every render. The
+  // unmount cleanup below must NOT depend on it — listing it made the cleanup
+  // fire on ordinary re-renders, tearing down the live metronome intervals
+  // mid-exercise (the count-in freeze on 2nd+ audio questions).
+  const stopContinuousMetronomeRef = useRef(stopContinuousMetronome);
+  stopContinuousMetronomeRef.current = stopContinuousMetronome;
 
   // Evaluate performance after user finishes tapping
   const evaluatePerformance = useCallback(() => {
@@ -674,8 +693,23 @@ export default function RhythmTapQuestion({
     const running = await audioEngine.ensureRunning();
     if (!running) {
       hasStartedRef.current = false;
+      if (import.meta.env.DEV) {
+        console.info("[rhythm count-in] TAP context not running, retrying", {
+          attempt: startRetryCountRef.current,
+          shared: audioContextRef.current?.state,
+          eng: audioEngine.audioContextRef?.current?.state,
+        });
+      }
+      if (startRetryCountRef.current < MAX_START_RETRIES) {
+        startRetryCountRef.current += 1;
+        startRetryTimerRef.current = setTimeout(
+          () => setStartRetryTick((n) => n + 1),
+          START_RETRY_MS
+        );
+      }
       return;
     }
+    startRetryCountRef.current = 0; // running — reset budget for future remounts
 
     // Prime the audio pipeline with a silent oscillator so the first
     // real click isn't swallowed by an uninitialized output buffer.
@@ -824,23 +858,24 @@ export default function RhythmTapQuestion({
     getCurrentOnsetInfo,
   ]);
 
-  // Auto-start when not disabled
+  // Auto-start when not disabled. startRetryTick re-arms this after a transient
+  // not-running AudioContext so the count-in self-heals (see startFlow).
   useEffect(() => {
     if (!disabled && phase === PHASES.INITIALIZING) {
       startFlow();
     }
-  }, [disabled, phase, startFlow]);
+  }, [disabled, phase, startFlow, startRetryTick]);
 
-  // Cleanup on unmount — cancel rAF loop (T-31-05) and stop metronome
+  // Cleanup on unmount ONLY — cancel rAF loop (T-31-05) and stop metronome.
+  // Empty deps so this fires exactly once on real unmount; the stop fn is read
+  // through a ref to avoid the identity-churn bug described above.
   useEffect(() => {
     return () => {
-      if (!cleanupDoneRef.current) {
-        cleanupDoneRef.current = true;
-        stopContinuousMetronome();
-        cancelAnimationFrame(rafIdRef.current);
-      }
+      stopContinuousMetronomeRef.current();
+      cancelAnimationFrame(rafIdRef.current);
+      if (startRetryTimerRef.current) clearTimeout(startRetryTimerRef.current);
     };
-  }, [stopContinuousMetronome]);
+  }, []);
 
   // Guidance text based on phase
   const getGuidanceText = () => {

--- a/src/components/games/rhythm-games/renderers/__tests__/PulseQuestion.test.jsx
+++ b/src/components/games/rhythm-games/renderers/__tests__/PulseQuestion.test.jsx
@@ -24,6 +24,13 @@ vi.mock("react-i18next", () => ({
   })),
 }));
 
+// Shared, controllable ensureRunning mock so a test can simulate a transient
+// not-running AudioContext (the count-in freeze regression). Hoisted so it can
+// be referenced inside the hoisted vi.mock factory below.
+const { ensureRunningMock } = vi.hoisted(() => ({
+  ensureRunningMock: vi.fn(() => Promise.resolve(true)),
+}));
+
 // Mock useAudioEngine — returns stub that avoids real Web Audio API
 // Path is relative to this test file (__tests__/ is one level deeper than renderers/)
 vi.mock("../../../../../hooks/useAudioEngine", () => ({
@@ -36,8 +43,8 @@ vi.mock("../../../../../hooks/useAudioEngine", () => ({
     createPianoSound: vi.fn(),
     // isReady() gates the count-in wait loop — return true so it exits at once.
     isReady: vi.fn(() => true),
-    // ensureRunning() gates the count-in — resolve true so scheduling proceeds.
-    ensureRunning: vi.fn(() => Promise.resolve(true)),
+    // ensureRunning() gates the count-in — controllable per test (default true).
+    ensureRunning: ensureRunningMock,
   })),
 }));
 
@@ -150,10 +157,16 @@ const defaultProps = {
   disabled: true, // disabled=true prevents auto-start flow (no timers)
 };
 
+// Mirrors START_RETRY_MS in PulseQuestion.jsx (count-in auto-start retry delay).
+const START_RETRY_MS = 150;
+
 describe("PulseQuestion", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     defaultProps.onComplete.mockClear();
+    // Default: AudioContext is running so the count-in proceeds immediately.
+    ensureRunningMock.mockReset();
+    ensureRunningMock.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -267,5 +280,43 @@ describe("PulseQuestion", () => {
     const { container } = render(<PulseQuestion {...defaultProps} />);
     expect(container).toBeTruthy();
     expect(screen.getByTestId("tap-area")).toBeInTheDocument();
+  });
+
+  // Regression: a remounted audio question (2nd+ in a MixedLessonGame) can briefly
+  // observe a not-yet-running shared AudioContext. The start must retry rather than
+  // bail permanently, otherwise the count-in/playback freezes forever.
+  it("retries the count-in after a transient not-running AudioContext (no permanent freeze)", async () => {
+    // 1st start attempt: context not running → bail + schedule retry.
+    // Retry attempt: running → count-in proceeds.
+    ensureRunningMock.mockReset();
+    ensureRunningMock.mockResolvedValueOnce(false).mockResolvedValue(true);
+
+    const onComplete = vi.fn();
+    render(
+      <PulseQuestion
+        question={defaultQuestion}
+        isLandscape={false}
+        onComplete={onComplete}
+        disabled={false}
+      />
+    );
+
+    // Flush the initial (failed) start attempt.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Still WAITING — count-in did not start, but it did NOT permanently bail.
+    expect(screen.getByText("Tap with the beat!")).toBeInTheDocument();
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // Fire the retry timer; the second attempt sees a running context.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(START_RETRY_MS);
+    });
+
+    // Count-in now running → guidance switches to the count-in text.
+    expect(screen.getByText("Listen to the beat...")).toBeInTheDocument();
+    expect(ensureRunningMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Problem

The rhythm trail **count-in / playback freeze** — the metronome count-in and pattern playback never fire, most often when the **Listen & repeat (tap)** (`rhythm_tap`), **read-and-tap** (`rhythm_reading`), or pulse game is the **2nd+ exercise** within a node.

This was root-caused and **device-confirmed as PR #4** (branch `fix/rhythm-countin-stuck`) back in June, but **PR #4 was never merged** and its branch went 16+ commits stale. The deployed `main` build never received the fix, so the bug persisted. This re-ports both proven fixes onto current `main`.

## Root causes (both verified still present in `main` before this change)

**1. Destructive cleanup effect (primary culprit).** All three audio renderers ended with `useEffect(() => { ...stopContinuousMetronome()... }, [stopContinuousMetronome])`. `stopContinuousMetronome` is a `useCallback` with `[audioEngine]` deps, and `useAudioEngine()` returns a fresh object every render, so the callback identity churns. Listing it in the cleanup deps turned "unmount cleanup" into "every-render cleanup", tearing down the live metronome + visual `setInterval` handles mid-exercise → frozen count-in.

**2. No-retry bail.** A remounted 2nd+ question can briefly observe a not-yet-running shared `AudioContext`; `if (!running) { ...; return; }` bailed permanently (the start effect never re-fired) → permanent freeze.

## Fix

- **Fix A — unmount-only cleanup (latest-ref):** read the stop fn through `stopContinuousMetronomeRef` with empty deps `[]`; drop `cleanupDoneRef`.
- **Fix B — bounded retry:** on `!running`, schedule a bounded retry (6 attempts, 150ms apart) via a `startRetryTick` state that re-arms the start effect; reset the budget on success; clear the timer on unmount.

Applied to `RhythmTapQuestion.jsx`, `RhythmReadingQuestion.jsx`, `PulseQuestion.jsx`. `RhythmReadingQuestion` was hand-ported (not checked out wholesale) to preserve main's newer `vexDurations` pattern loading (`56320d48`).

## Verification

- `npm run lint` → **0 errors**.
- New regression test in `PulseQuestion.test.jsx` (ensureRunning fails once then succeeds → count-in starts) passes.
- Full suite: **1934 passed**, 0 failures.
- ⏳ **Manual device verification needed** on this PR's Netlify preview: play `rhythm_1_1` / `rhythm_1_2` several times and reach the **2nd+ exercise** — count-in clicks must fire and the beat display advance every time (no freeze).

Supersedes #4 (stale branch `fix/rhythm-countin-stuck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)